### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,8 @@
     "rimraf": "^6.0.1",
     "web-vitals": "^2.1.4",
     "workbox-cli": "^7.3.0",
-    "workbox-webpack-plugin": "^7.3.0"
+    "workbox-webpack-plugin": "^7.3.0",
+    "dompurify": "^3.2.6"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/PrintableQuiz.js
+++ b/frontend/src/components/PrintableQuiz.js
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { Button, Card } from 'react-bootstrap';
+import DOMPurify from 'dompurify';
 
 const PrintableQuiz = ({ quiz, includeAnswers = false }) => {
     const printRef = useRef();
@@ -7,6 +8,7 @@ const PrintableQuiz = ({ quiz, includeAnswers = false }) => {
     // Handle print function
     const handlePrint = () => {
         const printContent = printRef.current.innerHTML;
+        const sanitizedTitle = DOMPurify.sanitize(quiz.title);
 
         // Create a new window for printing
         const printWindow = window.open('', '_blank', 'height=600,width=800');
@@ -16,7 +18,7 @@ const PrintableQuiz = ({ quiz, includeAnswers = false }) => {
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${quiz.title} - Printable Quiz</title>
+          <title>${sanitizedTitle} - Printable Quiz</title>
           <style>
             body {
               font-family: Arial, sans-serif;


### PR DESCRIPTION
Potential fix for [https://github.com/Mrintania/Signal-School-Quiz-Generator/security/code-scanning/7](https://github.com/Mrintania/Signal-School-Quiz-Generator/security/code-scanning/7)

To fix the issue, the `quiz.title` value should be sanitized or escaped before being interpolated into the HTML string in `PrintableQuiz.js`. The best approach is to use a library like `DOMPurify` to sanitize the input or `React`'s `dangerouslySetInnerHTML` with sanitized content. This ensures that any malicious HTML or JavaScript injected into `quiz.title` is neutralized.

**Steps to fix:**
1. Import `DOMPurify` into `PrintableQuiz.js`.
2. Use `DOMPurify.sanitize` to sanitize `quiz.title` before interpolating it into the HTML string.
3. Ensure that all other instances of `quiz.title` used in HTML contexts are similarly sanitized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
