### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/backend/src/utils/emailService.js
+++ b/backend/src/utils/emailService.js
@@ -40,8 +40,7 @@ const createTransporter = () => {
       logger.info(`From: ${mailOptions.from || process.env.EMAIL_FROM || 'no-reply@signalschool.com'}`);
       logger.info(`To: ${mailOptions.to}`);
       logger.info(`Subject: ${mailOptions.subject}`);
-      const sanitizedHtml = mailOptions.html.replace(/<li>Password:.*?<\/li>/, '<li>Password: [REDACTED]</li>');
-      logger.info(`HTML: ${sanitizedHtml.substring(0, 150)}...`);
+      logger.info('HTML content is present but not logged to avoid exposing sensitive information.');
       
       return Promise.resolve({
         accepted: [mailOptions.to],


### PR DESCRIPTION
Potential fix for [https://github.com/Mrintania/Signal-School-Quiz-Generator/security/code-scanning/9](https://github.com/Mrintania/Signal-School-Quiz-Generator/security/code-scanning/9)

To fix the issue, we need to ensure that sensitive information, such as passwords, is never logged. Instead of attempting to sanitize the HTML content, we should avoid logging the `HTML` field entirely. This ensures that no sensitive data is inadvertently exposed in the logs. 

The changes will involve:
1. Removing the logging of the `HTML` field in the preview-only transporter.
2. Optionally, logging a generic message indicating that the email contains HTML content without exposing its details.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
